### PR TITLE
Add ListProductBalances streaming RPC

### DIFF
--- a/fredrik_og_louisa/product/v1alpha/product.proto
+++ b/fredrik_og_louisa/product/v1alpha/product.proto
@@ -6,12 +6,18 @@ package fredrik_og_louisa.product.v1alpha;
 
 import "fredrik_og_louisa/decimal.proto";
 import "fredrik_og_louisa/money.proto";
+import "fredrik_og_louisa/time/date.proto";
 
 service ProductService {
   rpc ListProducts(ListProductsRequest) returns (stream Product);
+  rpc ListProductBalances(ListProductBalancesRequest) returns (stream ProductBalance);
 }
 
 message ListProductsRequest {}
+
+message ListProductBalancesRequest {
+  string warehouse_id = 1;
+}
 
 message Product {
   string sku = 1;
@@ -47,6 +53,15 @@ message Brand {
 message Category {
   string id = 1;
   string name = 2;
+}
+
+message ProductBalance {
+  string sku = 1;
+  sint32 on_hand = 2;
+  sint32 allocated = 3;
+  sint32 ordered_amount = 4;
+  // Last date a procurement order was placed for this product.
+  optional time.Date last_order_date = 5;
 }
 
 // TODO Does this belong here?


### PR DESCRIPTION
## Summary

- Add `ListProductBalances` streaming RPC to `ProductService`
- Add `ListProductBalancesRequest` (with `warehouse_id`) and `ProductBalance` message
- `ProductBalance` includes `sku`, `on_hand`, `allocated`, `ordered_amount`, and a stubbed `last_order_date`

Part of the streaming product balances feature for the external API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)