### PR TITLE
Add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  # Changes
+  $CHANGES
+categories:
+  - title: 'Breaking'
+    label: 'breaking'
+  - title: 'New'
+    label: 'feature'
+  - title: 'Bugfixes'
+    label: 'bug'
+  - title: 'Maintenance'
+    label: 'maintenance'
+
+# When graduating to 1.0.0, move 'breaking' from minor to a new major section
+# so that breaking changes trigger major version bumps.
+version-resolver:
+  minor:
+    labels:
+      - 'breaking'
+      - 'feature'
+  patch:
+    labels:
+      - 'bug'
+      - 'maintenance'
+  default: patch
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose

Adds automated release draft generation so that changelogs can be
generated from pull requests ahead of each release.

## Changes

- Added a release drafter GitHub Actions workflow that runs on each push
  to main
- Added release drafter configuration that categorizes PRs by label
  (breaking, feature, bug, maintenance) and auto-resolves the next
  version number

Both `breaking` and `feature` are mapped to minor bumps during the
current 0.x phase. When graduating to 1.0.0, `breaking` should be
moved to a major section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)