### PR TITLE
Rename last_ fields to past tense in ProductBalance

### DIFF
--- a/fredrik_og_louisa/product/v1alpha/product.proto
+++ b/fredrik_og_louisa/product/v1alpha/product.proto
@@ -61,9 +61,9 @@ message ProductBalance {
   sint32 allocated = 3;
   sint32 ordered_amount = 4;
   // Last date a procurement order was placed for this product
-  optional time.Date last_order_date = 5;
+  optional time.Date last_ordered_date = 5;
   // Last date a procurement order was received for this product
-  optional time.Date last_receipt_date = 6;
+  optional time.Date last_received_date = 6;
 }
 
 // TODO Does this belong here?


### PR DESCRIPTION
## Summary

- Renames `last_order_date` → `last_ordered_date` and `last_receipt_date` → `last_received_date` in `ProductBalance`
- Uses past participle forms to make it unambiguous that the fields describe when something last happened, rather than a planned final event
- Wire compatible (field numbers unchanged), but a breaking contract change for generated clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)