### PR TITLE
Add product type to product data

### DIFF
--- a/fredrik_og_louisa/product/v1alpha/product.proto
+++ b/fredrik_og_louisa/product/v1alpha/product.proto
@@ -25,6 +25,7 @@ message Product {
   string sku = 1;
   string ean = 12;
   ProductStatus status = 16;
+  ProductType type = 19;
   string name = 2;
   Brand brand = 3;
   Money sales_price = 4;
@@ -114,4 +115,15 @@ enum ProductStatus {
   // SKU has changed. This product has been discontinued via an item number change, or due to a misregistration.
   // It only exists for historical reference.
   PRODUCT_STATUS_SKU_CHANGED = 7;
+}
+
+enum ProductType {
+  PRODUCT_TYPE_UNSPECIFIED = 0;
+  PRODUCT_TYPE_NORMAL_PRODUCT = 1;
+  PRODUCT_TYPE_PARENT = 2;
+  PRODUCT_TYPE_TESTER = 3;
+  PRODUCT_TYPE_SAMPLE = 4;
+  PRODUCT_TYPE_GIFT_WITH_PURCHASE = 5;
+  PRODUCT_TYPE_SALES_SERVICE = 6;
+  PRODUCT_TYPE_MATERIAL = 7;
 }

--- a/fredrik_og_louisa/product/v1alpha/product.proto
+++ b/fredrik_og_louisa/product/v1alpha/product.proto
@@ -119,11 +119,32 @@ enum ProductStatus {
 
 enum ProductType {
   PRODUCT_TYPE_UNSPECIFIED = 0;
+  // A standard sellable product.
+  // This is the default classification and covers the bulk of the assortment.
   PRODUCT_TYPE_NORMAL_PRODUCT = 1;
+  // A grouping record for a set of variant children; not itself sellable.
+  // Variant children reference this product via `Variant.parent_sku`.
+  // Mutually exclusive with the `variant` field: a `PARENT` never has
+  // `variant` set, and a product with `variant` set is never `PARENT`.
   PRODUCT_TYPE_PARENT = 2;
+  // A product kept on the shop floor that customers can try before buying
+  // (e.g. a display unit customers can spray or apply). Not sellable.
   PRODUCT_TYPE_TESTER = 3;
+  // A small free portion (e.g. a sachet or miniature) of a product, given
+  // to the customer alongside a purchase to entice them to buy the full
+  // product. Samples exist only to be given away. Not sellable.
   PRODUCT_TYPE_SAMPLE = 4;
+  // A product given to the customer for free when their purchase meets
+  // certain criteria (e.g. a complimentary pouch on orders above a certain
+  // value), used to entice customers to qualify.
   PRODUCT_TYPE_GIFT_WITH_PURCHASE = 5;
+  // A product record representing a service or fee rather than physical
+  // merchandise. Examples include shipping fees, gift wrapping, gift cards,
+  // and in-store beauty treatments.
   PRODUCT_TYPE_SALES_SERVICE = 6;
+  // A product record representing an internal-use item rather than
+  // merchandise sold to customers. Examples include packaging supplies,
+  // store fixtures, staff uniforms, and marketing material such as signage
+  // or displays. Not sellable.
   PRODUCT_TYPE_MATERIAL = 7;
 }


### PR DESCRIPTION
Add a product type classification to `Product` via a new `ProductType` enum
and corresponding field.